### PR TITLE
Adjust the way PATH is ammended to reference the existing $PATH env var instead of embedding the value of it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN buildDeps=' \
     && rm -rf /rakudo.tar.gz /root/rakudo \
     && apt-get purge -y --auto-remove $buildDeps
 
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/perl6/site/bin/
+ENV PATH=$PATH:/usr/share/perl6/site/bin
 
 CMD ["rlwrap", "perl6"]


### PR DESCRIPTION
This makes sure that either Docker or the base image itself stay the "source of truth" for what the current value of PATH is, leaving `rakudo-star` only having to worry about what it's adding. :+1:
