### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: enabled
+services:
+    - docker
+script:
+    - docker build -t rakudo-star .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rakudo Star
 
+[![Build Status](https://travis-ci.org/perl6/docker.svg?branch=master)](https://travis-ci.org/perl6/docker)
+
 This Docker image includes Rakudo Star, an early adopter distribution of the Rakudo Perl 6 compiler, in addition
 to some modules users may find helpful.
 


### PR DESCRIPTION
This PR adds [Travis CI](https://travis-ci.org) integration to test that the image builds. The script in `.travis.yml` can be expanded to test the built image more thoroughly. 

You can see what the CI looks like at https://travis-ci.org/wolverian/docker.

The integration won't work until someone with admin rights to this repository gives Travis rights to read the repo, like documented at https://docs.travis-ci.com/user/getting-started.