### PR TITLE
Update default Rakudo Star version to 2018.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Rob Hoelz
 
 RUN groupadd -r perl6 && useradd -r -g perl6 perl6
 
-ARG rakudo_version=2018.06
+ARG rakudo_version=2018.10
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \


### PR DESCRIPTION
Update to newly released 2018.10