### PR TITLE
Update Rakudo Star version to 2019.03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Rob Hoelz
 
 RUN groupadd -r perl6 && useradd -r -g perl6 perl6
 
-ARG rakudo_version=2018.10
+ARG rakudo_version=2019.03
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \
@@ -12,9 +12,21 @@ RUN buildDeps=' \
         libencode-perl \
         make \
     ' \
+    \
+    keyfp=$( \
+        timestampFromDate() { \
+            date -d $(echo $1 | cut -c1-7 | tr . - | xargs printf '%s-01') '+%s'; \
+        }; \
+        \
+        if [ $(timestampFromDate $rakudo_version) -lt $(timestampFromDate '2019.03') ]; then \
+            echo 'ECF8B611205B447E091246AF959E3D6197190DD5'; \
+        else \
+            echo '7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D'; \
+        fi \
+    ) \
+    \
     url="https://rakudo.org/downloads/star/rakudo-star-${rakudo_version}.tar.gz" \
     keyserver='ha.pool.sks-keyservers.net' \
-    keyfp='ECF8B611205B447E091246AF959E3D6197190DD5' \
     tmpdir="$(mktemp -d)" \
     && set -x \
     && export GNUPGHOME="$tmpdir" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,9 @@ RUN buildDeps=' \
         make \
     ' \
     \
-    keyfp=$( \
-        timestampFromDate() { \
-            date -d $(echo $1 | cut -c1-7 | tr . - | xargs printf '%s-01') '+%s'; \
-        }; \
-        \
-        if [ $(timestampFromDate $rakudo_version) -lt $(timestampFromDate '2019.03') ]; then \
-            echo 'ECF8B611205B447E091246AF959E3D6197190DD5'; \
-        else \
-            echo '7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D'; \
-        fi \
-    ) \
-    \
     url="https://rakudo.org/downloads/star/rakudo-star-${rakudo_version}.tar.gz" \
     keyserver='ha.pool.sks-keyservers.net' \
+    keyfp='ECF8B611205B447E091246AF959E3D6197190DD5 7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D' \
     tmpdir="$(mktemp -d)" \
     && set -x \
     && export GNUPGHOME="$tmpdir" \


### PR DESCRIPTION
This updates the Rakudo Star version to 2019.03 from 2018.10.

The maintainer for Rakudo Star changed between 2018.10 and 2019.03 so
the existing fingerprint used to retrieve the key and verify the tarball
is not valid for the new release. Updating to include the new
fingerprint along with the previous one; the old one will be used if the
user sets the "rakudo_version" arg to a release prior to 2019.03 when
building.

See [Github Issue #23](https://github.com/perl6/docker/issues/23)