### PR TITLE
Build version 2020.01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN buildDeps=' \
         make \
     ' \
     \
-    url="https://rakudostar.com/files/star/rakudo-star-${rakudo_version}.tar.gz" \
+    url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
     keyserver='ha.pool.sks-keyservers.net' \
     keyfp='ECF8B611205B447E091246AF959E3D6197190DD5 7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D' \
     tmpdir="$(mktemp -d)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Rob Hoelz
 
 RUN groupadd -r perl6 && useradd -r -g perl6 perl6
 
-ARG rakudo_version=2019.03
+ARG rakudo_version=2020.01
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch-scm
+FROM buildpack-deps:buster-scm
 MAINTAINER Rob Hoelz
 
 RUN groupadd -r perl6 && useradd -r -g perl6 perl6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-scm
 MAINTAINER Rob Hoelz
 
-RUN groupadd -r perl6 && useradd -r -g perl6 perl6
+RUN groupadd -r raku && useradd -r -g raku raku
 
 ARG rakudo_version=2020.01
 ENV rakudo_version=${rakudo_version}
@@ -40,4 +40,4 @@ RUN buildDeps=' \
 
 ENV PATH=$PATH:/usr/share/perl6/site/bin
 
-CMD ["perl6"]
+CMD ["raku"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN buildDeps=' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
     keyserver='ha.pool.sks-keyservers.net' \
-    keyfp='ECF8B611205B447E091246AF959E3D6197190DD5 7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D' \
+    keyfp='ECF8B611205B447E091246AF959E3D6197190DD5 7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D B6F697742EFCAF5F23CE51D5031D65902E840821' \
     tmpdir="$(mktemp -d)" \
     && set -x \
     && export GNUPGHOME="$tmpdir" \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 RUN addgroup -S perl6 && adduser -S perl6 -G perl6
 
-ARG rakudo_version=2019.03
+ARG rakudo_version=2020.01
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \
@@ -14,9 +14,9 @@ RUN buildDeps=' \
         make \
     ' \
     \
-    url="https://rakudostar.com/files/star/rakudo-star-${rakudo_version}.tar.gz" \
+    url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
     keyserver='ha.pool.sks-keyservers.net' \
-    keyfp='ECF8B611205B447E091246AF959E3D6197190DD5 7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D' \
+    keyfp='ECF8B611205B447E091246AF959E3D6197190DD5 7A6C9EB8809CFEAF0ED4E09F18C438E6FF24326D B6F697742EFCAF5F23CE51D5031D65902E840821' \
     tmpdir="$(mktemp -d)" \
     && set -x \
     && export GNUPGHOME="$tmpdir" \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-RUN addgroup -S perl6 && adduser -S perl6 -G perl6
+RUN addgroup -S raku && adduser -S raku -G raku
 
 ARG rakudo_version=2020.01
 ENV rakudo_version=${rakudo_version}
@@ -39,4 +39,4 @@ RUN buildDeps=' \
 
 ENV PATH=$PATH:/usr/share/perl6/site/bin
 
-CMD ["perl6"]
+CMD ["raku"]


### PR DESCRIPTION
* Bump version to 2020.01
* Build based on Debian Buster, which has been stable for some time now (and avoids some GPG shenenigans)
* add the current Star maintainer's GPG key