### PR TITLE
Replace Perl with Raku

### DIFF
--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-Rakudo Perl 6, or simply Rakudo, is a compiler for the Perl 6 programming language.
+Rakudo is a compiler for the Raku programming language.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ you use the default version.
 Running a short-term foreground process with the image will launch a Raku REPL:
 
     $ docker run --rm -it rakudo-star
-    > say 'Hello, Perl!'
-    Hello, Perl!
+    > say 'Hello, Raku!'
+    Hello, Raku!
 
 You can also provide raku command line switches to a temporary container:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rakudo Star
 
-[![Build Status](https://travis-ci.org/raku/docker.svg?branch=master)](https://travis-ci.org/perl6/docker)
+[![Build Status](https://travis-ci.org/raku/docker.svg?branch=master)](https://travis-ci.org/Raku/docker)
 
 This Docker image includes Rakudo Star, which is a Raku compiler distribution that includes MoarVM
 virtual machine, Rakudo compiler, a suite of modules that users may find useful, and language documentation.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can also provide raku command line switches to a temporary container:
 
 In addition, you can run a script located in the current folder:
 
-    $ docker run --rm -v "$(pwd):/script" rakudo-star raku /script/my_p6_script.raku
+    $ docker run --rm -v "$(pwd):/script" rakudo-star raku /script/my_raku_script.raku
 
 # Contributing/Getting Help
 


### PR DESCRIPTION
While reading the README files, I noticed situations where `Perl` or `Perl 6` or `p6` were used instead of the relevant Raku equivalent.  This PR updates the README files to use the new name.  The PR is split into several commits so that they can be cherry-picked if so desired.  If you want any changes made to this PR, please let me know and I'll be happy to update and resubmit as necessary.