### PR TITLE
Remove unnecessary build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV rakudo_version=${rakudo_version}
 RUN buildDeps=' \
         gcc \
         libc6-dev \
-        libencode-perl \
         make \
     ' \
     \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,7 +12,6 @@ RUN buildDeps=' \
         libc-dev \
         make \
         perl \
-        perl-encode \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \


### PR DESCRIPTION
The [Encode module](https://metacpan.org/release/Encode) is not needed to build the Rakudo Star.