### PR TITLE
Add additional bin paths

### DIFF
--- a/2020.10/alpine3.12/Dockerfile
+++ b/2020.10/alpine3.12/Dockerfile
@@ -36,6 +36,6 @@ RUN buildDeps=' \
     && rm -rf $tmpdir \
     && apk del --no-network .build-deps
 
-ENV PATH=$PATH:/usr/share/perl6/site/bin
+ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 
 CMD ["raku"]

--- a/2020.10/buster/Dockerfile
+++ b/2020.10/buster/Dockerfile
@@ -36,6 +36,6 @@ RUN buildDeps=' \
     && rm -rf $tmpdir \
     && apt-get purge -y --auto-remove $buildDeps
 
-ENV PATH=$PATH:/usr/share/perl6/site/bin
+ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 
 CMD ["raku"]


### PR DESCRIPTION
When running `docker build` the following message is output:
```
You may need to add the following paths to your $PATH:
  /usr/bin
  /usr/share/perl6/site/bin
  /usr/share/perl6/vendor/bin
  /usr/share/perl6/core/bin
```

Currently only `/usr/share/perl6/site/bin` is added to `PATH`, but `zef` etc are in `/usr/share/perl6/vendor/bin`.