### PR TITLE
Update Rakudo Star and base images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
     - docker build -t rakudo-star ./$VERSION/$VARIANT
 
 env:
-    - VERSION='2022.02' VARIANT='buster'
-    - VERSION='2022.02' VARIANT='alpine3.13'
+    - VERSION='2022.02' VARIANT='bullseye'
+    - VERSION='2022.02' VARIANT='alpine3.15'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
     - docker build -t rakudo-star ./$VERSION/$VARIANT
 
 env:
-    - VERSION='2021.04' VARIANT='buster'
-    - VERSION='2021.04' VARIANT='alpine3.13'
+    - VERSION='2022.02' VARIANT='buster'
+    - VERSION='2022.02' VARIANT='alpine3.13'

--- a/2022.02/alpine3.13/Dockerfile
+++ b/2022.02/alpine3.13/Dockerfile
@@ -1,15 +1,17 @@
-FROM buildpack-deps:buster-scm
-MAINTAINER Rob Hoelz
+FROM alpine:3.13
 
-RUN groupadd -r raku && useradd -m -r -g raku raku
+RUN addgroup -S raku && adduser -S raku -G raku
 
-ARG rakudo_version=2021.04
+ARG rakudo_version=2022.02-01
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \
+        bash \
         gcc \
-        libc6-dev \
+        gnupg \
+        libc-dev \
         make \
+        perl \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
@@ -18,13 +20,11 @@ RUN buildDeps=' \
     tmpdir="$(mktemp -d)" \
     && set -eux \
     && export GNUPGHOME="$tmpdir" \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $buildDeps \
-    && rm -rf /var/lib/apt/lists/* \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
     && mkdir ${tmpdir}/rakudo \
     \
-    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
-    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
+    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
+    && wget $url -O ${tmpdir}/rakudo.tar.gz \
     && gpg --batch --keyserver $keyserver --recv-keys $keyfp \
     && gpg --batch --verify ${tmpdir}/rakudo.tar.gz.asc ${tmpdir}/rakudo.tar.gz \
     \
@@ -34,7 +34,7 @@ RUN buildDeps=' \
         && bash bin/rstar install -p /usr \
     ) \
     && rm -rf $tmpdir \
-    && apt-get purge -y --auto-remove $buildDeps
+    && apk del --no-network .build-deps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 

--- a/2022.02/alpine3.15/Dockerfile
+++ b/2022.02/alpine3.15/Dockerfile
@@ -1,15 +1,17 @@
-FROM buildpack-deps:buster-scm
-MAINTAINER Rob Hoelz
+FROM alpine:3.15
 
-RUN groupadd -r raku && useradd -m -r -g raku raku
+RUN addgroup -S raku && adduser -S raku -G raku
 
 ARG rakudo_version=2022.02-01
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \
+        bash \
         gcc \
-        libc6-dev \
+        gnupg \
+        libc-dev \
         make \
+        perl \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
@@ -18,13 +20,11 @@ RUN buildDeps=' \
     tmpdir="$(mktemp -d)" \
     && set -eux \
     && export GNUPGHOME="$tmpdir" \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $buildDeps \
-    && rm -rf /var/lib/apt/lists/* \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
     && mkdir ${tmpdir}/rakudo \
     \
-    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
-    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
+    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
+    && wget $url -O ${tmpdir}/rakudo.tar.gz \
     && gpg --batch --keyserver $keyserver --recv-keys $keyfp \
     && gpg --batch --verify ${tmpdir}/rakudo.tar.gz.asc ${tmpdir}/rakudo.tar.gz \
     \
@@ -34,7 +34,7 @@ RUN buildDeps=' \
         && bash bin/rstar install -p /usr \
     ) \
     && rm -rf $tmpdir \
-    && apt-get purge -y --auto-remove $buildDeps
+    && apk del --no-network .build-deps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 

--- a/2022.02/alpine3.15/Dockerfile
+++ b/2022.02/alpine3.15/Dockerfile
@@ -8,25 +8,20 @@ ENV rakudo_version=${rakudo_version}
 RUN buildDeps=' \
         bash \
         gcc \
-        gnupg \
         libc-dev \
         make \
         perl \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
-    keyserver='ha.pool.sks-keyservers.net' \
-    keyfp='B6F697742EFCAF5F23CE51D5031D65902E840821' \
+    sha256='bb658a67b792c355bbfad71e3d486b6c18bbfa108260c53bf351d8c40a1ad42a' \
     tmpdir="$(mktemp -d)" \
     && set -eux \
-    && export GNUPGHOME="$tmpdir" \
     && apk add --no-cache --virtual .build-deps $buildDeps \
     && mkdir ${tmpdir}/rakudo \
     \
-    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
     && wget $url -O ${tmpdir}/rakudo.tar.gz \
-    && gpg --batch --keyserver $keyserver --recv-keys $keyfp \
-    && gpg --batch --verify ${tmpdir}/rakudo.tar.gz.asc ${tmpdir}/rakudo.tar.gz \
+    && echo $sha256 ${tmpdir}/rakudo.tar.gz | sha256sum -c - \
     \
     && tar xzf ${tmpdir}/rakudo.tar.gz --strip-components=1 -C ${tmpdir}/rakudo \
     && ( \

--- a/2022.02/alpine3.15/Dockerfile
+++ b/2022.02/alpine3.15/Dockerfile
@@ -5,7 +5,8 @@ RUN addgroup -S raku && adduser -S raku -G raku
 ARG rakudo_version=2022.02-01
 ENV rakudo_version=${rakudo_version}
 
-RUN buildDeps=' \
+RUN set -eux; \
+    buildDeps=' \
         bash \
         gcc \
         libc-dev \
@@ -15,21 +16,20 @@ RUN buildDeps=' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
     sha256='bb658a67b792c355bbfad71e3d486b6c18bbfa108260c53bf351d8c40a1ad42a' \
-    tmpdir="$(mktemp -d)" \
-    && set -eux \
-    && apk add --no-cache --virtual .build-deps $buildDeps \
-    && mkdir ${tmpdir}/rakudo \
+    tmpdir="$(mktemp -d)"; \
+    apk add --no-cache --virtual .build-deps $buildDeps; \
+    mkdir ${tmpdir}/rakudo; \
     \
-    && wget $url -O ${tmpdir}/rakudo.tar.gz \
-    && echo $sha256 ${tmpdir}/rakudo.tar.gz | sha256sum -c - \
+    wget $url -O ${tmpdir}/rakudo.tar.gz; \
+    echo $sha256 ${tmpdir}/rakudo.tar.gz | sha256sum -c -; \
     \
-    && tar xzf ${tmpdir}/rakudo.tar.gz --strip-components=1 -C ${tmpdir}/rakudo \
-    && ( \
-        cd ${tmpdir}/rakudo \
-        && bash bin/rstar install -p /usr \
-    ) \
-    && rm -rf $tmpdir \
-    && apk del --no-network .build-deps
+    tar xzf ${tmpdir}/rakudo.tar.gz --strip-components=1 -C ${tmpdir}/rakudo; \
+    ( \
+        cd ${tmpdir}/rakudo; \
+        bash bin/rstar install -p /usr \
+    ); \
+    rm -rf $tmpdir; \
+    apk del --no-network .build-deps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 

--- a/2022.02/bullseye/Dockerfile
+++ b/2022.02/bullseye/Dockerfile
@@ -6,7 +6,8 @@ RUN groupadd -r raku && useradd -m -r -g raku raku
 ARG rakudo_version=2022.02-01
 ENV rakudo_version=${rakudo_version}
 
-RUN buildDeps=' \
+RUN set -eux; \
+    buildDeps=' \
         gcc \
         libc6-dev \
         make \
@@ -14,23 +15,22 @@ RUN buildDeps=' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
     sha256='bb658a67b792c355bbfad71e3d486b6c18bbfa108260c53bf351d8c40a1ad42a' \
-    tmpdir="$(mktemp -d)" \
-    && set -eux \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $buildDeps \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir ${tmpdir}/rakudo \
+    tmpdir="$(mktemp -d)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $buildDeps; \
+    rm -rf /var/lib/apt/lists/*; \
+    mkdir ${tmpdir}/rakudo; \
     \
-    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
-    && echo $sha256 ${tmpdir}/rakudo.tar.gz | sha256sum -c - \
+    curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz; \
+    echo $sha256 ${tmpdir}/rakudo.tar.gz | sha256sum -c -; \
     \
-    && tar xzf ${tmpdir}/rakudo.tar.gz --strip-components=1 -C ${tmpdir}/rakudo \
-    && ( \
-        cd ${tmpdir}/rakudo \
-        && bash bin/rstar install -p /usr \
-    ) \
-    && rm -rf $tmpdir \
-    && apt-get purge -y --auto-remove $buildDeps
+    tar xzf ${tmpdir}/rakudo.tar.gz --strip-components=1 -C ${tmpdir}/rakudo; \
+    ( \
+        cd ${tmpdir}/rakudo; \
+        bash bin/rstar install -p /usr \
+    ); \
+    rm -rf $tmpdir; \
+    apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 

--- a/2022.02/bullseye/Dockerfile
+++ b/2022.02/bullseye/Dockerfile
@@ -13,20 +13,16 @@ RUN buildDeps=' \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
-    keyserver='ha.pool.sks-keyservers.net' \
-    keyfp='B6F697742EFCAF5F23CE51D5031D65902E840821' \
+    sha256='bb658a67b792c355bbfad71e3d486b6c18bbfa108260c53bf351d8c40a1ad42a' \
     tmpdir="$(mktemp -d)" \
     && set -eux \
-    && export GNUPGHOME="$tmpdir" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir ${tmpdir}/rakudo \
     \
-    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
     && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
-    && gpg --batch --keyserver $keyserver --recv-keys $keyfp \
-    && gpg --batch --verify ${tmpdir}/rakudo.tar.gz.asc ${tmpdir}/rakudo.tar.gz \
+    && echo $sha256 ${tmpdir}/rakudo.tar.gz | sha256sum -c - \
     \
     && tar xzf ${tmpdir}/rakudo.tar.gz --strip-components=1 -C ${tmpdir}/rakudo \
     && ( \

--- a/2022.02/bullseye/Dockerfile
+++ b/2022.02/bullseye/Dockerfile
@@ -1,17 +1,15 @@
-FROM alpine:3.13
+FROM buildpack-deps:bullseye-scm
+MAINTAINER Rob Hoelz
 
-RUN addgroup -S raku && adduser -S raku -G raku
+RUN groupadd -r raku && useradd -m -r -g raku raku
 
 ARG rakudo_version=2022.02-01
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \
-        bash \
         gcc \
-        gnupg \
-        libc-dev \
+        libc6-dev \
         make \
-        perl \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
@@ -20,11 +18,13 @@ RUN buildDeps=' \
     tmpdir="$(mktemp -d)" \
     && set -eux \
     && export GNUPGHOME="$tmpdir" \
-    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir ${tmpdir}/rakudo \
     \
-    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
-    && wget $url -O ${tmpdir}/rakudo.tar.gz \
+    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
+    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
     && gpg --batch --keyserver $keyserver --recv-keys $keyfp \
     && gpg --batch --verify ${tmpdir}/rakudo.tar.gz.asc ${tmpdir}/rakudo.tar.gz \
     \
@@ -34,7 +34,7 @@ RUN buildDeps=' \
         && bash bin/rstar install -p /usr \
     ) \
     && rm -rf $tmpdir \
-    && apk del --no-network .build-deps
+    && apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 

--- a/2022.02/buster/Dockerfile
+++ b/2022.02/buster/Dockerfile
@@ -1,17 +1,15 @@
-FROM alpine:3.13
+FROM buildpack-deps:buster-scm
+MAINTAINER Rob Hoelz
 
-RUN addgroup -S raku && adduser -S raku -G raku
+RUN groupadd -r raku && useradd -m -r -g raku raku
 
-ARG rakudo_version=2021.04
+ARG rakudo_version=2022.02-01
 ENV rakudo_version=${rakudo_version}
 
 RUN buildDeps=' \
-        bash \
         gcc \
-        gnupg \
-        libc-dev \
+        libc6-dev \
         make \
-        perl \
     ' \
     \
     url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
@@ -20,11 +18,13 @@ RUN buildDeps=' \
     tmpdir="$(mktemp -d)" \
     && set -eux \
     && export GNUPGHOME="$tmpdir" \
-    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir ${tmpdir}/rakudo \
     \
-    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
-    && wget $url -O ${tmpdir}/rakudo.tar.gz \
+    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
+    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
     && gpg --batch --keyserver $keyserver --recv-keys $keyfp \
     && gpg --batch --verify ${tmpdir}/rakudo.tar.gz.asc ${tmpdir}/rakudo.tar.gz \
     \
@@ -34,7 +34,7 @@ RUN buildDeps=' \
         && bash bin/rstar install -p /usr \
     ) \
     && rm -rf $tmpdir \
-    && apk del --no-network .build-deps
+    && apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 


### PR DESCRIPTION
1. Rakudo Star to 2022.02
2. Debian to 11 (bullseye)
3. Alpine Linux to 3.15