### PR TITLE
Bump to 2024.03 and change alpine to alpine:latest

### DIFF
--- a/2024.03/alpine/Dockerfile
+++ b/2024.03/alpine/Dockerfile
@@ -1,32 +1,34 @@
-FROM buildpack-deps:bookworm-scm
-MAINTAINER Rob Hoelz
+FROM alpine:latest
 
-RUN groupadd -r raku && useradd -m -r -g raku raku
+RUN addgroup -S raku && adduser -S raku -G raku
 
-ARG rakudo_version=2024.02-01
-ENV rakudo_version=${rakudo_version}
+ARG rakudo_version=2024.03
+ARG rakudo_build_revision=01
+ENV rakudo_full_version=${rakudo_version}-${rakudo_build_revision}
 
 RUN buildDeps=' \
+        bash \
         gcc \
-        libc6-dev \
+        gnupg \
+        libc-dev \
         make \
+        perl \
     ' \
     \
-    url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
+    url="https://rakudo.org/dl/star/rakudo-star-${rakudo_full_version}.tar.gz" \
     keyfp="3E7E3C6EAF916676AC549285A2919382E961E2EE" \
     pubkeyurl="https://rakudo.org/keys/rakudo_github_automation-${keyfp}.asc" \
     tmpdir="$(mktemp -d)" \
     && set -eux \
-    && export GNUPGHOME="$tmpdir/gnupg" \
+    && export GNUPGHOME="${tmpdir}/gnupg" \
     && mkdir $GNUPGHOME \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $buildDeps \
-    && rm -rf /var/lib/apt/lists/* \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache readline \
     && mkdir ${tmpdir}/rakudo \
     \
-    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
-    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
-    && curl -fsSL $pubkeyurl -o ${tmpdir}/key.asc \
+    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
+    && wget $url -O ${tmpdir}/rakudo.tar.gz \
+    && wget $pubkeyurl -O ${tmpdir}/key.asc \
     \
     && gpg --batch --import ${tmpdir}/key.asc \
     && gpg --batch --export $keyfp > ${tmpdir}/${keyfp}.asc \
@@ -41,7 +43,7 @@ RUN buildDeps=' \
         && bash bin/rstar install -p /usr \
     ) \
     && rm -rf $tmpdir \
-    && apt-get purge -y --auto-remove $buildDeps
+    && apk del --no-network .build-deps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 

--- a/2024.03/bookworm/Dockerfile
+++ b/2024.03/bookworm/Dockerfile
@@ -1,33 +1,33 @@
-FROM alpine:3.19
+FROM buildpack-deps:bookworm-scm
+MAINTAINER Rob Hoelz
 
-RUN addgroup -S raku && adduser -S raku -G raku
+RUN groupadd -r raku && useradd -m -r -g raku raku
 
-ARG rakudo_version=2024.02-01
-ENV rakudo_version=${rakudo_version}
+ARG rakudo_version=2024.03
+ARG rakudo_build_revision=01
+ENV rakudo_full_version=${rakudo_version}-${rakudo_build_revision}
 
 RUN buildDeps=' \
-        bash \
         gcc \
-        gnupg \
-        libc-dev \
+        libc6-dev \
         make \
-        perl \
     ' \
     \
-    url="https://rakudo.org/dl/star/rakudo-star-${rakudo_version}.tar.gz" \
+    url="https://rakudo.org/dl/star/rakudo-star-${rakudo_full_version}.tar.gz" \
     keyfp="3E7E3C6EAF916676AC549285A2919382E961E2EE" \
     pubkeyurl="https://rakudo.org/keys/rakudo_github_automation-${keyfp}.asc" \
     tmpdir="$(mktemp -d)" \
     && set -eux \
-    && export GNUPGHOME="${tmpdir}/gnupg" \
+    && export GNUPGHOME="$tmpdir/gnupg" \
     && mkdir $GNUPGHOME \
-    && apk add --no-cache --virtual .build-deps $buildDeps \
-    && apk add --no-cache readline \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir ${tmpdir}/rakudo \
     \
-    && wget ${url}.asc -O ${tmpdir}/rakudo.tar.gz.asc \
-    && wget $url -O ${tmpdir}/rakudo.tar.gz \
-    && wget $pubkeyurl -O ${tmpdir}/key.asc \
+    && curl -fsSL ${url}.asc -o ${tmpdir}/rakudo.tar.gz.asc \
+    && curl -fsSL $url -o ${tmpdir}/rakudo.tar.gz \
+    && curl -fsSL $pubkeyurl -o ${tmpdir}/key.asc \
     \
     && gpg --batch --import ${tmpdir}/key.asc \
     && gpg --batch --export $keyfp > ${tmpdir}/${keyfp}.asc \
@@ -42,7 +42,7 @@ RUN buildDeps=' \
         && bash bin/rstar install -p /usr \
     ) \
     && rm -rf $tmpdir \
-    && apk del --no-network .build-deps
+    && apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH=$PATH:/usr/share/perl6/core/bin:/usr/share/perl6/site/bin:/usr/share/perl6/vendor/bin
 


### PR DESCRIPTION
@m-dango @Altai-man @moritz @jmaslak 

As far as can I see, the alpine image version was kept "latest" manually... so with this commit, beside bumping the Star version, I'd like to switch to alpine:latest to simplify things... hope thats ok for everyone.

Should I have missed some "good reasons" to stay on selective alpine versions, pls let me know...

thanks & regards